### PR TITLE
修复web敏感词触发时的提示

### DIFF
--- a/sparkdesk_web/core.py
+++ b/sparkdesk_web/core.py
@@ -113,6 +113,8 @@ class SparkWeb:
                     answer = decode(encoded_data).replace('\n\n', '\n')
                     response_text += answer
 
+        if len(response_text.strip()) == 0:
+            print("WARNING: 可能触发敏感词监控，对话已被重置，请前往Web页面更新Cookie、fd、GtToken！")
         return response_text
 
     def __streaming_output(self, question):
@@ -129,7 +131,7 @@ class SparkWeb:
                     answer = decode(encoded_data).replace('\n\n', '\n')
                     response_text += answer
                     print(answer, end="")
-        if response_text is None:
+        if len(response_text.strip()) == 0:
             return '', False
         print("\n")
         return response_text, True

--- a/sparkdesk_web_cli.py
+++ b/sparkdesk_web_cli.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
 
     # continue chat
     chat = sparkWeb.create_continuous_chat()
-    # while True:
-    #     print(chat.chat(input("Ask: ")))
-    print(chat.chat("肇庆是一个什么样的城市"))
-    print(chat.chat("刚才你说的是哪个城市？"))
+    while True:
+        chat.chat(input("Ask: "))
+    # chat.chat("肇庆是一个什么样的城市")
+    # chat.chat("刚才你说的是哪个城市？")


### PR DESCRIPTION
触发敏感词会导致response_text的值为空，但判空方式似乎是错误的is None，将其修正为另一种判空方式。